### PR TITLE
Remove Duplicate Keys To Remove Warning

### DIFF
--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -29,7 +29,7 @@ module Aggcat
     end
 
     def account_confirmation(institution_id, challenge_session_id, challenge_node_id, answers)
-      validate(institution_id: institution_id, challenge_node_id: challenge_session_id, challenge_node_id: challenge_node_id, answers: answers)
+      validate(institution_id: institution_id, challenge_session_id: challenge_session_id, challenge_node_id: challenge_node_id, answers: answers)
       headers = {'challengeSessionId' => challenge_session_id, 'challengeNodeId' => challenge_node_id}
       post("/institutions/#{institution_id}/logins", challenge_answers(answers), headers)
     end
@@ -70,7 +70,7 @@ module Aggcat
     end
 
     def update_login_confirmation(login_id, challenge_session_id, challenge_node_id, answers)
-      validate(login_id: login_id, challenge_node_id: challenge_session_id, challenge_node_id: challenge_node_id, answers: answers)
+      validate(login_id: login_id, challenge_session_id: challenge_session_id, challenge_node_id: challenge_node_id, answers: answers)
       headers = {'challengeSessionId' => challenge_session_id, 'challengeNodeId' => challenge_node_id}
       put("/logins/#{login_id}?refresh=true", challenge_answers(answers), headers)
     end


### PR DESCRIPTION
Prevents

```
/Users/rkowalick/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/aggcat-36515400924a/lib/aggcat/client.rb:32: warning: key :challenge_node_id is duplicated and overwritten on line 32
/Users/rkowalick/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/aggcat-36515400924a/lib/aggcat/client.rb:73: warning: key :challenge_node_id is duplicated and overwritten on line 73
/Users/rkowalick/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/aggcat-36515400924a/lib/aggcat/client.rb:32: warning: key :challenge_node_id is duplicated and overwritten on line 32
/Users/rkowalick/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/aggcat-36515400924a/lib/aggcat/client.rb:73: warning: key :challenge_node_id is duplicated and overwritten on line 73
```

from appearing.